### PR TITLE
Proposed Idea: add session identifier

### DIFF
--- a/dnstap.proto
+++ b/dnstap.proto
@@ -38,6 +38,12 @@ message Dnstap {
     // the payload. No encoding or interpretation is applied or enforced.
     optional bytes      extra = 3;
 
+    // Unique session id
+    // If enabled, this is uniq string for all resolution tasks.
+    // This field is very useful for matching all DNS requests related to particular
+    // domain resolution session
+    optional bytes      session = 4;
+
     // Identifies which field below is filled in.
     enum Type {
         MESSAGE = 1;


### PR DESCRIPTION
Hello!

As part of our DNS TAP experience it's very useful to have special field for matching multiple recursive DNS resolution requests into big one "resolution session" for analytics.

We started to use "extra" field for such purposes but I think it could be useful for standard to have session identifier also.