### PR TITLE
Use consistent whitespace

### DIFF
--- a/dnstap.proto
+++ b/dnstap.proto
@@ -167,15 +167,15 @@ message Message {
         // tool from a DNS server, from the perspective of the tool.
         TOOL_RESPONSE = 12;
 
-	// UPDATE_QUERY is a DNS update query message received from a resolver
-	// by an authoritative name server, from the perspective of the
-	// authoritative name server.
-	UPDATE_QUERY = 13;
+        // UPDATE_QUERY is a DNS update query message received from a resolver
+        // by an authoritative name server, from the perspective of the
+        // authoritative name server.
+        UPDATE_QUERY = 13;
 
-	// UPDATE_RESPONSE is a DNS update response message sent from an
-	// authoritative name server to a resolver, from the perspective of the
-	// authoritative name server.
-	UPDATE_RESPONSE = 14;
+        // UPDATE_RESPONSE is a DNS update response message sent from an
+        // authoritative name server to a resolver, from the perspective of the
+        // authoritative name server.
+        UPDATE_RESPONSE = 14;
     }
 
     // One of the Type values described above.


### PR DESCRIPTION
This commit makes the whitespace consistent by using spaces for indentation.