### PR TITLE
Add HttpProtocol enum and http_protocol field to Message

### DIFF
--- a/dnstap.proto
+++ b/dnstap.proto
@@ -67,6 +67,14 @@ enum SocketProtocol {
     DOQ = 7;         // DNS over QUIC (RFC 9250)
 }
 
+// HttpProtocol: the HTTP protocol version used to transport a DNS message over
+// an HTTP-based protocol such as DNS over HTTPS.
+enum HttpProtocol {
+    HTTP1 = 1; // HTTP/1
+    HTTP2 = 2; // HTTP/2
+    HTTP3 = 3; // HTTP/3
+}
+
 // Policy: information about any name server operator policy
 // applied to the processing of a DNS message.
 message Policy {
@@ -285,6 +293,10 @@ message Message {
 
     // Operator policy applied to the processing of this message, if any.
     optional Policy             policy = 15;
+
+    // One of the HttpProtocol values described above. This field should only be
+    // set if socket_protocol is set to DOH.
+    optional HttpProtocol       http_protocol = 16;
 }
 
 // All fields except for 'type' in the Message schema are optional.


### PR DESCRIPTION
This commit adds a new `HttpProtocol` enum that represents HTTP versions and adds an optional `http_protocol` field to the `Message` message. This allows specifying the particular HTTP version used if the DOH protocol is in use.

Hypothetically, this field could be used in the future to specify the HTTP version in use for an HTTP-based DNS transport protocol that is not the currently existing RFC 8484 DOH protocol. However, at the time of this writing none of the other currently defined dnstap `SocketProtocol` values are HTTP-based transports, so the `http_protocol` field should only be set if `socket_protocol` is set to DOH. Otherwise, the `http_protocol` field should be left unset.